### PR TITLE
fix issue with epel include

### DIFF
--- a/zfs/init.sls
+++ b/zfs/init.sls
@@ -2,7 +2,7 @@
 {% if grains['os_family'] == 'RedHat' %}
 
 include:
-  - epel-formula
+  - epel
 
 {% if grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {


### PR DESCRIPTION
I converted a deployment with this and epel-formula as entries under file_roots to gitfs, and then zfs-formula quit working because it could not find epel-formula on the master anymore. When I changed epel-formula to epel in init.sls, the problem disappeared.

This also matches the example in the [formulas documentation](http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html#including-a-formula-in-an-existing-state-tree).
